### PR TITLE
fix: avoid infinite loop in runtime state

### DIFF
--- a/packages/react/src/context/react/utils/useRuntimeState.ts
+++ b/packages/react/src/context/react/utils/useRuntimeState.ts
@@ -1,4 +1,4 @@
-import { useDebugValue, useSyncExternalStore } from "react";
+import { useDebugValue, useSyncExternalStore, useRef, useCallback } from "react";
 import { Unsubscribe } from "../../../types";
 import { ensureBinding } from "./ensureBinding";
 
@@ -7,6 +7,25 @@ export type SubscribableRuntime<TState> = {
   subscribe: (callback: () => void) => Unsubscribe;
 };
 
+function shallowEqual(objA: any, objB: any): boolean {
+  if (objA === objB) return true;
+  if (
+    typeof objA !== "object" ||
+    objA === null ||
+    typeof objB !== "object" ||
+    objB === null
+  ) {
+    return false;
+  }
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+  if (keysA.length !== keysB.length) return false;
+  for (const key of keysA) {
+    if (objA[key] !== objB[key]) return false;
+  }
+  return true;
+}
+
 export function useRuntimeStateInternal<TState, TSelected>(
   runtime: SubscribableRuntime<TState>,
   selector: ((state: TState) => TSelected | TState) | undefined = identity,
@@ -14,13 +33,28 @@ export function useRuntimeStateInternal<TState, TSelected>(
   // TODO move to useRuntimeState
   ensureBinding(runtime);
 
+  const lastSnapshot = useRef<TSelected | TState>(null);
+
+  const getSnapshot = useCallback(() => {
+    const newSnapshot = selector(runtime.getState());
+    if (
+      lastSnapshot.current !== undefined &&
+      shallowEqual(lastSnapshot.current, newSnapshot)
+    ) {
+      return lastSnapshot.current;
+    }
+    lastSnapshot.current = newSnapshot;
+    return newSnapshot;
+  }, [runtime, selector]);
+
   const slice = useSyncExternalStore(
     runtime.subscribe,
-    () => selector(runtime.getState()),
-    () => selector(runtime.getState()),
+    getSnapshot,
+    getSnapshot
   );
+
   useDebugValue(slice);
-  return slice;
+  return slice as TSelected | TState;
 }
 
 const identity = <T>(arg: T): T => arg;


### PR DESCRIPTION
Fixes infinite refetching loop triggered by importing `{ useThread }`. 

More specifically, two errors are currently thrown when you import `useThread`
`The result of getSnapshot should be cached to avoid an infinite loop` -> `Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.`

Details on the error, including steps to reproduce, and testing of this change, is in a Neeto I recorded [here](https://erichasegawa.neetorecord.com/watch/8b248975de50cb802128) (1 minute video that should provide all context needed for reviewing)